### PR TITLE
Legacy Sheet Compatibility and Bugfixes

### DIFF
--- a/css/darksheet.css
+++ b/css/darksheet.css
@@ -423,7 +423,7 @@ option.ddValueBad {
     text-align: center;
 }
 .woundroll:hover::before {
-    content: "Reopen ";
+    /*content: "Reopen ";*/ /* This made the Reopen Wounds button read "ReopenReopen Wounds" when hovered. */
   }
 .woundInformation {
     font-size: 20px;

--- a/darksheet.js
+++ b/darksheet.js
@@ -283,7 +283,7 @@ async function addWoundsToSheet(sheet, html, data) {
     //RENDER WOUNDS
     var woundBarDiv = document.createElement("div");
     woundBarDiv.classList.add("pills-group", "woundsection", "woundS1");
-    woundBarDiv.innerHTML = '<button type="button" class="rollable button" title="Click to roll for reopened wounds" class="deathsavelabel woundroll rollReopenWounds rollable" actorid="' + actor.id + '">Reopen Wounds</button><button type="button" class="rollable button addwoundbutton" id="addwound" actorID="' + sheet.actor.id + '"><i class="fas fa-plus"></i> Add Wound</button>';
+    woundBarDiv.innerHTML = '<button type="button" class="rollable button deathsavelabel woundroll rollReopenWounds" title="Click to roll for reopened wounds" actorid="' + actor.id + '">Reopen Wounds</button><button type="button" class="rollable button addwoundbutton" id="addwound" actorID="' + sheet.actor.id + '"><i class="fas fa-plus"></i> Add Wound</button>';
 
     let woundTable = await renderTemplate("modules/darksheet/templates/wounds.html", data);
 

--- a/darksheet.js
+++ b/darksheet.js
@@ -641,14 +641,16 @@ async function darkSheetSetup(app, html, data) {
         // Ensure that item.flags.darksheet?.item?.slots and item.system.quantity are defined, otherwise use 0
         const slots = item.flags?.darksheet?.item?.slots ?? 0;
         const quantity = item.system?.quantity ?? 0;
-
-        if (!(game.settings.get('darksheet', 'equippedDontUseSlots') && item.system.equipped)) {
+        
+        // Added support for Griddy inventory module to slot calculation. Equipped items that are excluded from Griddy don't contribue to currentSlots.
+        if (!(game.settings.get('darksheet', 'equippedDontUseSlots') && item.system.equipped) && !(item.system.equipped && item.flags.griddy.position.e))
+        {
             currentSlots += slots * quantity;
         }
 
     });
 
-    let maxSlots = 18;
+    let maxSlots = 10;
     let percentage = 0;
     let STRBONUS = actor.system.abilities.str.value * Math.max(1, Math.min(actor.system.attributes.encumbrance.mod, 8));
 
@@ -661,7 +663,7 @@ async function darkSheetSetup(app, html, data) {
                 maxSlots = 14;
                 break;
             case "med":
-                maxSlots = 18;
+                maxSlots = 10;
                 break;
             case "lg":
                 maxSlots = 22;
@@ -673,7 +675,7 @@ async function darkSheetSetup(app, html, data) {
                 maxSlots = 46;
                 break;
             default:
-                maxSlots = 18;
+                maxSlots = 10;
                 break;
         }
 

--- a/darksheet.js
+++ b/darksheet.js
@@ -524,7 +524,23 @@ async function addDarkSheetTab(app, html, data) {
     //ADD NEW DD TAB
 
     let test = html.find(".tabs").append('<a class="item control" data-group="primary" data-tab="dd" data-tooltip="Darker Dungeons" aria-label="Darker Dungeons"><i class="fas fa-skull"></i></a>');
-    let sheet = html.find(".tab-body");
+    let sheet;
+
+    // When attempting to create the Darksheet tab, fallback to legacy sheet locations if necessary.
+    if (html.find(".tab-body").length > 0)
+    {
+        sheet = html.find(".tab-body");
+    }
+    else if (html.find(".sheet-body").length > 0)
+    {
+        sheet = html.find(".sheet-body");
+    }
+    else
+    {
+        console.error("Darksheet: Unable to find where to place DarkSheet tab content.");
+        return;
+    }
+
     let hideChecks = game.settings.get("darksheet", "hidechecks");
     data.hidechecks = hideChecks;
     let darkSheetTabHTML = await renderTemplate("modules/darksheet/templates/Tab_DD.html", data);

--- a/templates/Tab_DD.html
+++ b/templates/Tab_DD.html
@@ -55,8 +55,8 @@
                 </div>
             <div class="part3 {{actor._id}} allparts items-section card">
                     <h4 class="darksheetheader {{actor._id}} items-header header">Fatigue</h4>
-                    <div class="staminaCheck">
-                        <label class="dicelabel2 staminacheck rollable darkcheck check">Stamina Check</label>
+                    <div class="staminaCheck staminacheck">
+                        <label class="dicelabel2 rollable darkcheck check">Stamina Check</label>
                     </div>
                     <select class="darkselect" name="flags.darksheet.attributes.fatigue" data-type="String">
                         {{#select actor.flags.darksheet.attributes.fatigue}}


### PR DESCRIPTION
Hi Handyfon, recently discovered DarkerDungeons and wanted to use it in Foundry. I found and loved this module you made, but came across a few bugs, as well as wanting to use the Legacy sheet or Compact D&D Beyond sheet. I've put together a few bugfixes and compatibility tweaks to make your module's content show up on the Legacy, and Compact D&D Beyond sheets.

I'm not really a javascript dev, and it's my first time editing a Foundry module so hopefully my changes seem rational, let me know if anything is amiss. The Legacy compatibility is definitly a bit rough, but it at least provides the functionality.

### Legacy Sheet Compatibility:
Added rudimentry validation when searching for elements to add content to. If the new sheet locations cannot be found, it falls back to using the Legacy sheet locations.

- DarkerDungeons tab now properly displays its contents on Legacy sheets.
- Added error handling to large portions of the inventory/encumbrance setup as it otherwise throws fatal errors on legacy sheets that prevent further sheet setup from executing.
- Added back the Wounds section to the Legacy sheets.

### Bugfixes:

- Reopen Wounds Button not working: Fixed element classes being declared in two places in the element definition resulting in most of the classes being ignored.
- Fixed Reopen Wounds button reading ReopenReopen Wounds when hovered due to css style.
- Fixed Stamina Check button only being interactable when clicking the central text by moving element class up to the parent div.